### PR TITLE
Add Persistence

### DIFF
--- a/charts/ignition/Chart.yaml
+++ b/charts/ignition/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: ignition
 description: Simple helm chart for deploying Ignition into Kubernetes
 type: application
-version: 0.1.6 # Chart version
+version: 0.1.7 # Chart version
 appVersion: "8.1.47" # Ignition gateway image version
 icon: https://raw.githubusercontent.com/electricallen/ignition-helm/main/assets/icon.svg

--- a/charts/ignition/templates/NOTES.txt
+++ b/charts/ignition/templates/NOTES.txt
@@ -36,3 +36,4 @@ To access the gateway run:
 The gateway will then be available in browser and through designer at:
     http://localhost:{{ $httpPort }}
 {{- end }}
+Please allow at least 30 seconds for the gateway to start

--- a/charts/ignition/templates/deployment.yaml
+++ b/charts/ignition/templates/deployment.yaml
@@ -74,3 +74,11 @@ spec:
                 - 'curl -sf http://localhost:{{ $httpPort }}/StatusPing | grep -q RUNNING'
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ignition/templates/deployment.yaml
+++ b/charts/ignition/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if not .Values.eula.accepted }}
+{{- fail "EULA must be accepted. Please set 'eula.accepted=true' in your values.yaml or via --set. See https://inductiveautomation.com/ignition/license" }}
+{{- end }}
 {{- $httpPort := "" }}
 {{- $httpsPort := "" }}
 {{- $ganPort := "" }}

--- a/charts/ignition/templates/eula.yaml
+++ b/charts/ignition/templates/eula.yaml
@@ -1,3 +1,0 @@
-{{- if not .Values.eula.accepted }}
-{{- fail "EULA must be accepted. Please set 'eula.accepted=true' in your values.yaml or via --set. See https://inductiveautomation.com/ignition/license" }}
-{{- end }}

--- a/charts/ignition/templates/statefulSet.yaml
+++ b/charts/ignition/templates/statefulSet.yaml
@@ -14,16 +14,17 @@
   {{- end }}
 {{- end }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "ignition.fullname" . }}
   labels:
     {{- include "ignition.labels" . | nindent 4 }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       {{- include "ignition.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "ignition.fullname" . }}
+  replicas: 1
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -81,7 +82,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- with .Values.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/ignition/templates/statefulSet.yaml
+++ b/charts/ignition/templates/statefulSet.yaml
@@ -80,7 +80,7 @@ spec:
             periodSeconds: 5
       {{- if .Values.volumeClaimTemplates }}
           volumeMounts:
-            - name: ignition-data
+            - name: {{ (index .Values.volumeClaimTemplates 0).metadata.name }}
               mountPath: /usr/local/bin/ignition/data
       initContainers:
         - name: "init-{{ .Chart.Name }}"
@@ -89,16 +89,16 @@ spec:
           command: ["/bin/sh", "-c"]
           args: # Mount PVC to a temp dir; if non-empty, copy data from the image to the temp dir
             - |
-              if [ ! -f /tmp/ignition-data/gateway.xml_clean ]; 
+              if [ ! -f /tmp/gw-data/gateway.xml_clean ]; 
               then
-                cp -a /usr/local/bin/ignition/data/* /tmp/ignition-data
+                cp -a /usr/local/bin/ignition/data/* /tmp/gw-data
                 echo "Volume initialized"
               else
                 echo "Volume already initialized, passing"
               fi
           volumeMounts:
-            - name: ignition-data
-              mountPath: /tmp/ignition-data
+            - name: {{ (index .Values.volumeClaimTemplates 0).metadata.name }}
+              mountPath: /tmp/gw-data
       {{- end }}
     {{- with .Values.volumeClaimTemplates }}
   volumeClaimTemplates:

--- a/charts/ignition/templates/statefulSet.yaml
+++ b/charts/ignition/templates/statefulSet.yaml
@@ -81,11 +81,10 @@ spec:
           volumeMounts:
             - name: ignition-data
               mountPath: /usr/local/bin/ignition/data
-          {{- end }}
       initContainers:
-        - name: init-ignition
+        - name: "init-{{ .Chart.Name }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args: # Mount PVC to a temp dir; if non-empty, copy data from the image to the temp dir
             - |

--- a/charts/ignition/templates/statefulSet.yaml
+++ b/charts/ignition/templates/statefulSet.yaml
@@ -78,6 +78,7 @@ spec:
                 - 'curl -sf http://localhost:{{ $httpPort }}/StatusPing | grep -q RUNNING'
             initialDelaySeconds: 10
             periodSeconds: 5
+      {{- if .Values.volumeClaimTemplates }}
           volumeMounts:
             - name: ignition-data
               mountPath: /usr/local/bin/ignition/data
@@ -98,6 +99,7 @@ spec:
           volumeMounts:
             - name: ignition-data
               mountPath: /tmp/ignition-data
+      {{- end }}
     {{- with .Values.volumeClaimTemplates }}
   volumeClaimTemplates:
     {{- toYaml . | nindent 4 }}

--- a/charts/ignition/templates/statefulSet.yaml
+++ b/charts/ignition/templates/statefulSet.yaml
@@ -78,10 +78,23 @@ spec:
                 - 'curl -sf http://localhost:{{ $httpPort }}/StatusPing | grep -q RUNNING'
             initialDelaySeconds: 10
             periodSeconds: 5
-          {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            - name: ignition-data
+              mountPath: /usr/local/bin/ignition/data
           {{- end }}
+      initContainers:
+        - name: init-ignition
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args: # Mount PVC to a temp dir; if non-empty, copy data from the image to the temp dir
+            - |
+              if [ ! -f /tmp/ignition-data/gateway.xml_clean ]; then
+                cp -a /usr/local/bin/ignition/data/* /tmp/ignition-data
+              fi
+          volumeMounts:
+            - name: ignition-data
+              mountPath: /tmp/ignition-data
     {{- with .Values.volumeClaimTemplates }}
   volumeClaimTemplates:
     {{- toYaml . | nindent 4 }}

--- a/charts/ignition/templates/statefulSet.yaml
+++ b/charts/ignition/templates/statefulSet.yaml
@@ -88,8 +88,12 @@ spec:
           command: ["/bin/sh", "-c"]
           args: # Mount PVC to a temp dir; if non-empty, copy data from the image to the temp dir
             - |
-              if [ ! -f /tmp/ignition-data/gateway.xml_clean ]; then
+              if [ ! -f /tmp/ignition-data/gateway.xml_clean ]; 
+              then
                 cp -a /usr/local/bin/ignition/data/* /tmp/ignition-data
+                echo "Volume initialized"
+              else
+                echo "Volume already initialized, passing"
               fi
           volumeMounts:
             - name: ignition-data

--- a/charts/ignition/values.yaml
+++ b/charts/ignition/values.yaml
@@ -32,6 +32,7 @@ service:
       protocol: TCP
       port: 8060
 
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
   className: traefik
@@ -43,3 +44,16 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true

--- a/charts/ignition/values.yaml
+++ b/charts/ignition/values.yaml
@@ -54,4 +54,4 @@ volumeClaimTemplates: []
   #     resources:
   #       requests:
   #         storage: 1Gi
-  #     storageClassName: local-path # adjust or template in values.yaml
+  #     storageClassName: local-path

--- a/charts/ignition/values.yaml
+++ b/charts/ignition/values.yaml
@@ -39,21 +39,24 @@ ingress:
   annotations: {}
   portName: http
   hosts:
-    - host: ignition.local
+    - host: ignition.localhost
       paths:
         - path: /
           pathType: Prefix
   tls: []
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
 # Additional volumeMounts on the output Deployment definition.
+
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
+  # - name: ignition-data
+  #   mountPath: /usr/local/bin/ignition/data
+
+# Additional volumeClaimTemplates on the output Deployment definition.
+volumeClaimTemplates: []
+  # - metadata:
+  #     name: ignition-data
+  #   spec:
+  #     accessModes: ["ReadWriteOncePod"]
+  #     resources:
+  #       requests:
+  #         storage: 1Gi
+  #     storageClassName: local-path # adjust or template in values.yaml

--- a/charts/ignition/values.yaml
+++ b/charts/ignition/values.yaml
@@ -48,7 +48,7 @@ ingress:
 # Additional volumeClaimTemplates on the output Deployment definition.
 volumeClaimTemplates: []
   # - metadata:
-  #     name: ignition-data
+  #     name: data
   #   spec:
   #     accessModes: ["ReadWriteOncePod"]
   #     resources:

--- a/charts/ignition/values.yaml
+++ b/charts/ignition/values.yaml
@@ -44,11 +44,6 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
-# Additional volumeMounts on the output Deployment definition.
-
-volumeMounts: []
-  # - name: ignition-data
-  #   mountPath: /usr/local/bin/ignition/data
 
 # Additional volumeClaimTemplates on the output Deployment definition.
 volumeClaimTemplates: []


### PR DESCRIPTION
Adds the ability to enable persistence by configuring `Values.volumeClaimTemplates`. When this setting is configured:

* A volumeMount is added to the application at  `/usr/local/bin/ignition/data`
* A volumeClaimTemplate is added to the statefulSet
* An init container is added that loads the ignition data from the image into a volume if it is empty, seeding the PVC for the application container

This can be disabled by setting `Values.volumeClaimTemplates` = `[]`